### PR TITLE
Add head-only formula for whatsmeow branch of whatscli

### DIFF
--- a/Formula/whatscli-whatsmeow.rb
+++ b/Formula/whatscli-whatsmeow.rb
@@ -1,0 +1,29 @@
+class WhatscliWhatsmeow < Formula
+  desc "Command-line interface for WhatsApp (whatsmeow branch)"
+  homepage "https://github.com/normen/whatscli/tree/whatsmeow"
+  license "MIT"
+
+  head do
+    url "https://github.com/normen/whatscli.git", branch: "whatsmeow"
+  end
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"whatsmeow")
+  end
+
+  test do
+    #system "#{bin}/whatsmeow"
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test whatscli`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/Formula/whatscli.rb
+++ b/Formula/whatscli.rb
@@ -5,6 +5,10 @@ class Whatscli < Formula
   sha256 "b4b2ceb1c4babe5fc53284714aebf102477543df247e2a25b533e4271d0622d7"
   license "MIT"
 
+  head do
+    url "https://github.com/normen/whatscli.git", branch: "master"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/whatscli.rb
+++ b/Formula/whatscli.rb
@@ -8,9 +8,7 @@ class Whatscli < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-o", "whatscli"
-    mkdir bin.to_s
-    cp "whatscli", "#{bin}/"
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 
 
 ## Included formulae
+
 - [whatscli](https://github.com/normen/whatscli)
+- [whatscli-meow](https://github.com/normen/whatscli/tree/whatsmeow) (`whatsmeow` branch of `whatscli`)
 
 ## How do I install these formulae?
+
 `brew install normen/tap/<formula>`
 
 Or `brew tap normen/tap` and then `brew install <formula>`.
 
+**NOTE:** `whatscli-meow` is a head-only formula, so you must use the `--HEAD` argument to `brew install`.
+
+``` shellsession
+$ brew install --HEAD normen/tap/whatscli-meow
+```
+
 ## Documentation
+
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
This PR adds a head-only formula for the [whatsmeow](https://github.com/normen/whatscli/tree/whatsmeow) branch of [whatscli](https://github.com/normen/whatscli). This should allow users to install and test that version with little overhead, as requested by @martin-braun in https://github.com/normen/whatscli/issues/72#issuecomment-1428736411.

This PR also includes a small cleanup to the original `whatscli` formula, and adds `--HEAD` support to that formula, as well.